### PR TITLE
[BugFix]Fix broken link to image in informed lesson 1

### DIFF
--- a/Informed/Lesson One/README.md
+++ b/Informed/Lesson One/README.md
@@ -176,7 +176,7 @@ The first `if` branch is executed only if the return value of our function call 
 
 You can even double check this behaviour by ⎇-clicking on the variable. 
 
-![Unwrapped optional](unwrapped.png)
+![Unwrapped optional](img/unwrapped.png)
 
 The `else` statement is executed if the value _was_ `nil`.
 


### PR DESCRIPTION
Fixes a broken img link.
<img width="591" alt="screen shot 2015-08-18 at 08 17 43" src="https://cloud.githubusercontent.com/assets/231790/9334525/24c40a7a-4584-11e5-91ee-3ed861f48070.png">
