### PR TITLE
Fixed some typos in the Informed Lessons

### DIFF
--- a/Informed/Lesson Five/README.md
+++ b/Informed/Lesson Five/README.md
@@ -174,7 +174,7 @@ Just like we can force-unwrap an optional, we can force-unwrap the optional retu
 try! inventory.buyItemNamed("shoes", withCreditCard: creditCard)
 ```
 
-The thing is, if an error _is_ thrown, then you app crashes. `try!` is just as dangerous as force unwrapping an optional and should be avoided whenever possible.
+The thing is, if an error _is_ thrown, then your app crashes. `try!` is just as dangerous as force unwrapping an optional and should be avoided whenever possible.
 
 Let's return to our throwing function. It's pretty ugly, eh? All that indenting! Let's rearrange things with `guard` statements. 
 
@@ -214,7 +214,7 @@ mutating func buyItemNamed(name: String, withCreditCard creditCard: CreditCard) 
 
 Super-nice!
 
-One more thing I'd like to mention is the `defer` keyword. This is useful for when we need something to happen when program execution exits a scope, no matter how it exits. `defer` can be used as a sort of `finally` to execute something that must be accomplished no matter what. Let's take a trivial examples. 
+One more thing I'd like to mention is the `defer` keyword. This is useful for when we need something to happen when program execution exits a scope, no matter how it exits. `defer` can be used as a sort of `finally` to execute something that must be accomplished no matter what. Let's take a trivial example. 
 
 ```swift
 mutating func buyItemNamed(name: String, withCreditCard creditCard: CreditCard) throws -> Item {

--- a/Informed/Lesson Four/README.md
+++ b/Informed/Lesson Four/README.md
@@ -209,7 +209,7 @@ extension CollectionType where Self: Occupiable { }
 
 This will compile, but due to a limitation in the current Swift compiler, it doesn't actually work. Oh well 😄
 
-OK, so protocol extensions are neat I guess, but they gets _even_ cooler. We can extend an existing type that uses generics, and then constrain the extension to cases where the generic type conforms to a protocol. 
+OK, so protocol extensions are neat I guess, but they get _even_ cooler. We can extend an existing type that uses generics, and then constrain the extension to cases where the generic type conforms to a protocol. 
 
 ಠ_ಠ
 

--- a/Informed/Lesson Two/README.md
+++ b/Informed/Lesson Two/README.md
@@ -155,6 +155,9 @@ So let's change `b` to be a `var`. We can access these properties and they shoul
 Now let's get weirder. Let's create two new variables assigned to `a` and `b`.
 
 ```swift
+var a2 = a
+var b2 = b
+
 a2.property = "Hello"
 b2.property = "Hello"
 ```
@@ -335,7 +338,7 @@ func doSomething<T>(input: T) -> T {
 
 This is a really silly function – all it does is return what you give it. But it's declaration is interesting. The angle brackets mean that it works on a generic, named `T`. We can name it whatever we want, though. 
 
-The parameter `input` is of type `T`, even though we don't know what that is right now. Also, the function has to return something else of type `T`. We can all this function with nearly anything:
+The parameter `input` is of type `T`, even though we don't know what that is right now. Also, the function has to return something else of type `T`. We can call this function with nearly anything:
 
 ```swift
 doSomething("hi")


### PR DESCRIPTION
Fixed some typos, and made one of the code examples clearer.
