### PR TITLE
Fix some typos in Informed lesson four and five.

### DIFF
--- a/Informed/Lesson Five/Lesson Five.playground/Contents.swift
+++ b/Informed/Lesson Five/Lesson Five.playground/Contents.swift
@@ -18,7 +18,7 @@
 //: - Avoid overuse of `throw`.
 //: - Compile-time safety.
 //: 
-//: Forcing functions to be marked as `throws` lets the compiler verify that the invoking code handle the error somehow. Super-cool!
+//: Forcing functions to be marked as `throws` lets the compiler verify that the invoking code handles the error somehow. Super-cool!
 //: 
 //: Another difference between exceptions and Swift's... whatever it's called is that you can throw any type, as long as it conforms to the `ErrorType` protocol. What's in that protocol? Nothing!
 // public protocol ErrorType {}
@@ -276,7 +276,7 @@ func contains(suspect: Character) -> (String -> Bool) {
 input.filter(contains("@"))
 //: The `contains` function returns a function of type `String -> Bool`, which is what our `filter` function wants – cool!
 //: 
-//: This sort of thing is so common that Swift actually as shorthand syntax.
+//: This sort of thing is so common that Swift actually has shorthand syntax.
 //func contains(suspect: Character)(string: String) -> Bool {
 //  return string.characters.contains(suspect)
 //}

--- a/Informed/Lesson Five/README.md
+++ b/Informed/Lesson Five/README.md
@@ -18,7 +18,7 @@ A function that throws errors must explicitly be marked as `throws`, otherwise y
 - Avoid overuse of `throw`.
 - Compile-time safety.
 
-Forcing functions to be marked as `throws` lets the compiler verify that the invoking code handle the error somehow. Super-cool!
+Forcing functions to be marked as `throws` lets the compiler verify that the invoking code handles the error somehow. Super-cool!
 
 Another difference between exceptions and Swift's... whatever it's called is that you can throw any type, as long as it conforms to the `ErrorType` protocol. What's in that protocol? Nothing!
 
@@ -363,7 +363,7 @@ input.filter(contains("@"))
 
 The `contains` function returns a function of type `String -> Bool`, which is what our `filter` function wants – cool!
 
-This sort of thing is so common that Swift actually as shorthand syntax.
+This sort of thing is so common that Swift actually has shorthand syntax.
 
 ```swift
 func contains(suspect: Character)(string: String) -> Bool {

--- a/Informed/Lesson Four/Lessons Four.playground/Contents.swift
+++ b/Informed/Lesson Four/Lessons Four.playground/Contents.swift
@@ -147,7 +147,7 @@ extension CollectionType where Self: Occupiable { }
 //: 
 //: That's a lot to unwrap, so let's go over that again.
 //: 
-//: Some types work on generics, like our `Stack`. We can define an extension on `Stack` that _only_ works certain stacks. These stacks need to be stacks of something that conforms to another protocol.
+//: Some types work on generics, like our `Stack`. We can define an extension on `Stack` that _only_ works for certain stacks. These stacks need to be stacks of something that conforms to another protocol.
 extension Stack where T: Occupiable {
   
 }

--- a/Informed/Lesson Four/README.md
+++ b/Informed/Lesson Four/README.md
@@ -215,7 +215,7 @@ OK, so protocol extensions are neat I guess, but they get _even_ cooler. We can 
 
 That's a lot to unwrap, so let's go over that again. 
 
-Some types work on generics, like our `Stack`. We can define an extension on `Stack` that _only_ works certain stacks. These stacks need to be stacks of something that conforms to another protocol. 
+Some types work on generics, like our `Stack`. We can define an extension on `Stack` that _only_ works for certain stacks. These stacks need to be stacks of something that conforms to another protocol. 
 
 ```swift
 extension Stack where T: Occupiable {

--- a/Informed/Lesson Three/Lesson Three.playground/Contents.swift
+++ b/Informed/Lesson Three/Lesson Three.playground/Contents.swift
@@ -6,7 +6,7 @@
 //: 
 //: ## Closures
 //: 
-//: A "closure" is a difficult term to define precisely because to different people, the term connotes different ideas and different amounts of precision. For _this_ lesson, we're going to define closures as code that is can be referred to and invoked, but that _isn't_ a function.
+//: A "closure" is a difficult term to define precisely because to different people, the term connotes different ideas and different amounts of precision. For _this_ lesson, we're going to define closures as code that can be referred to and invoked, but that _isn't_ a function.
 //: 
 //: Closures have a place in most modern programming languages, even if they're called by a different name. For example, Javascript has anonymous functions.
 //:
@@ -87,11 +87,11 @@ func add(lhs: Int, rhs: Int) -> Int { return lhs + rhs }
 //: 
 //: ## Lazy Loading
 //: 
-//: A _lazy_ variable is one that doesn't have its value set until it is first accessed. That means if it is set to a type that get initialized, that initialization will be delayed until the lazy variable is first read from.
+//: A _lazy_ variable is one that doesn't have its value set until it is first accessed. That means if it is set to a type that gets initialized, that initialization will be delayed until the lazy variable is first read from.
 //: 
 //: This is valuable when you have a resource-intensive thing that shouldn't be created before it's used. For example, an image that takes up a lot of RAM (which is scarce on iPhones), or a complex computation that takes several seconds to execute.
 //: 
-//: (Note: all global variables are lazy to avoid consuming too many at app startup, probably.)
+//: (Note: all global variables are lazy to avoid consuming too many resources at app startup, probably.)
 //: 
 //: Of course, the downside of lazy properties is that they delay execution of code that could be done before its needed. It's a balance that's up to each coder in each circumstance.
 //: 


### PR DESCRIPTION
A few other fixes for Informed lesson four and five.

Additionally, this fixes the same typos in the playground files for Informed lesson three that were fixed only in the markdown readme file in pull request #23.

Thanks again, great tutorials to get started :+1: 
